### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
Potential fix for [https://github.com/kjell5317/nosql-toolbox2/security/code-scanning/1](https://github.com/kjell5317/nosql-toolbox2/security/code-scanning/1)

To fix this problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to only what is needed. Since none of the steps in this workflow require write access to the repository or to issues/pull-requests (the steps only install, test, and upload artifacts), setting `permissions: contents: read` at the workflow root is sufficient and recommended. This change should be placed right after the `name:` and before `on:` in the `.github/workflows/playwright.yml` file for clarity and maximum coverage, ensuring all jobs in this workflow inherit the permissions restriction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
